### PR TITLE
Special casing zero length files

### DIFF
--- a/osfclient/models/storage.py
+++ b/osfclient/models/storage.py
@@ -87,6 +87,13 @@ class Storage(OSFCore, ContainerMixin):
                 parent = parent.create_folder(directory, exist_ok=True)
 
         url = parent._new_file_url
-        response = self._put(url, params={'name': fname}, data=fp)
+        # peek at the file to check if it is an ampty file which needs special
+        # handling in requests. If we pass a file like object to data that
+        # turns out to be of length zero then no file is created on the OSF
+        if fp.peek(1):
+            response = self._put(url, params={'name': fname}, data=fp)
+        else:
+            response = self._put(url, params={'name': fname}, data=b'')
+
         if response.status_code == 409:
             raise FileExistsError(path)

--- a/osfclient/tests/test_storage.py
+++ b/osfclient/tests/test_storage.py
@@ -162,3 +162,25 @@ def test_create_new_file_subdirectory():
                 call(new_file_url, params={'name': 'foo.txt'}, data=fake_fp)]
     assert mock_put.call_args_list == expected
     assert fake_fp.call_count == 0
+
+
+def test_create_new_zero_length_file():
+    # check zero length files are special cased
+    new_file_url = ('https://files.osf.io/v1/resources/9zpcy/providers/' +
+                    'osfstorage/foo123/')
+    store = Storage({})
+    store._new_file_url = new_file_url
+    store._put = MagicMock(return_value=FakeResponse(201, None))
+
+    fake_fp = MagicMock()
+    fake_fp.peek = lambda x: ''
+
+    store.create_file('foo.txt', fake_fp)
+
+    store._put.assert_called_once_with(new_file_url,
+                                       # this is the important check in
+                                       # this test
+                                       data=b'',
+                                       params={'name': 'foo.txt'})
+
+    assert fake_fp.call_count == 0


### PR DESCRIPTION
Fixes #32

This seems like a bug in `requests` which sends a `Transfer-encoding: chunked` header but doesn't do anything for zero length files?

By `peek`ing at the file to see if there is anything in it we (I think) can detect empty files and then pass an empty byte string to `requests` which seems to work.