### PR TITLE
[MRG] Fix package discovery

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 # Always prefer setuptools over distutils
-from setuptools import setup
+from setuptools import setup, find_packages
 
 
 setup(
@@ -36,7 +36,7 @@ setup(
 
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
-    packages=['osfclient'],
+    packages=find_packages(),
 
     # List run-time dependencies here.  These will be installed by pip when
     # your project is installed. For an analysis of "install_requires" vs pip's


### PR DESCRIPTION
I tried to install `osfclient` with
`$ pip install https://github.com/dib-lab/osf-cli/archive/master.tar.gz`

When I try to run it, I get an ImportError:
```$ osf
 File "/usr/lib/python3.5/site-packages/osfclient/api.py", line 1, in <module>
    from .models import OSFCore
ImportError: No module named 'osfclient.models'
```

Seems like the issue is the `packages` field, it is not including all the modules in the package (like `osfclient.models`). I used `find_packages` to do this automatically.