### PR TITLE
[MRG] Fix typo in license link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Contributors to the project are required to follow the [code of
 conduct](CONDUCT.md).
 
 By contributing, you are agreeing that we may redistribute your work under
-[this license](license).
+[this license](LICENSE).
 
 We use the [GitHub flow](https://guides.github.com/introduction/flow/) model
 for contributions.


### PR DESCRIPTION
Simplez. Thanks to [@stephwright](https://github.com/mozilla/global-sprint/issues/123#issuecomment-305208712)