### PR TITLE
[WIP] Fix check for empty file when on python 2

### DIFF
--- a/osfclient/models/storage.py
+++ b/osfclient/models/storage.py
@@ -5,6 +5,8 @@ from .core import OSFCore
 from .file import ContainerMixin
 from .file import File
 from ..utils import norm_remote_path
+from ..utils import file_empty
+
 
 if six.PY2:
     class FileExistsError(OSError):
@@ -103,11 +105,10 @@ class Storage(OSFCore, ContainerMixin):
         # peek at the file to check if it is an ampty file which needs special
         # handling in requests. If we pass a file like object to data that
         # turns out to be of length zero then no file is created on the OSF
-        not_empty = fp.peek(1)
-        if not_empty:
-            response = self._put(url, params={'name': fname}, data=fp)
-        else:
+        if file_empty(fp):
             response = self._put(url, params={'name': fname}, data=b'')
+        else:
+            response = self._put(url, params={'name': fname}, data=fp)
 
         if response.status_code == 409:
             if not update:

--- a/osfclient/tests/test_storage.py
+++ b/osfclient/tests/test_storage.py
@@ -1,6 +1,7 @@
 from mock import patch, MagicMock, call
 
 import pytest
+import six
 
 from osfclient.models import OSFCore
 from osfclient.models import Storage
@@ -256,7 +257,10 @@ def test_create_new_zero_length_file():
 
     fake_fp = MagicMock()
     fake_fp.mode = 'rb'
-    fake_fp.peek = lambda x: ''
+    if six.PY3:
+        fake_fp.peek = lambda: ''
+    if six.PY2:
+        fake_fp.read = lambda: ''
 
     store.create_file('foo.txt', fake_fp)
 

--- a/osfclient/tests/test_utils.py
+++ b/osfclient/tests/test_utils.py
@@ -1,5 +1,6 @@
-from mock import call, patch
+from mock import call, patch, Mock
 
+from osfclient.utils import file_empty
 from osfclient.utils import norm_remote_path
 from osfclient.utils import makedirs
 from osfclient.utils import split_storage
@@ -84,3 +85,25 @@ def test_makedirs_py3(mock_makedirs):
 
     expected = [call('/this/path/exists', 511, True)]
     assert expected == mock_makedirs.mock_calls
+
+
+def test_empty_file():
+    fake_fp = Mock()
+    with patch('osfclient.utils.six.PY2', False):
+        empty = file_empty(fake_fp)
+
+    expected = [call.peek()]
+    assert expected == fake_fp.mock_calls
+    # mocks and calls on mocks always return True, so this should be False
+    assert not empty
+
+
+def test_empty_file_py2():
+    fake_fp = Mock()
+    with patch('osfclient.utils.six.PY2', True):
+        empty = file_empty(fake_fp)
+
+    expected = [call.read(), call.seek(0)]
+    assert expected == fake_fp.mock_calls
+    # mocks and calls on mocks always return True, so this should be False
+    assert not empty

--- a/osfclient/utils.py
+++ b/osfclient/utils.py
@@ -49,7 +49,6 @@ def makedirs(path, mode=511, exist_ok=False):
 def file_empty(fp):
     """Determine if a file is empty or not."""
     # for python 2 we need to use a homemade peek()
-    print('py3?', six.PY2)
     if six.PY2:
         contents = fp.read()
         fp.seek(0)

--- a/osfclient/utils.py
+++ b/osfclient/utils.py
@@ -44,3 +44,16 @@ def makedirs(path, mode=511, exist_ok=False):
             return None
         else:
             return os.makedirs(path, mode)
+
+
+def file_empty(fp):
+    """Determine if a file is empty or not."""
+    # for python 2 we need to use a homemade peek()
+    print('py3?', six.PY2)
+    if six.PY2:
+        contents = fp.read()
+        fp.seek(0)
+        return not bool(contents)
+
+    else:
+        return not fp.peek()


### PR DESCRIPTION
Fixes #75 

In python 2 there is no `peek()`, so implemented our own.

Does someone know why `six` does not have a compatibility thing for this?

* [ ] test the new function