### PR TITLE
[MRG] Recursively upload files

### DIFF
--- a/osfclient/__main__.py
+++ b/osfclient/__main__.py
@@ -69,11 +69,14 @@ def main():
     list_parser = _add_subparser('list', list.__doc__, aliases=['ls'])
     list_parser.set_defaults(func=list_)
 
-    # Upload a single file
+    # Upload a single file or a directory tree
     upload_parser = _add_subparser('upload', upload.__doc__)
     upload_parser.set_defaults(func=upload)
     upload_parser.add_argument('-f', '--force',
                                help='Force overwriting of remote file',
+                               action='store_true')
+    upload_parser.add_argument('-r', '--recursive',
+                               help='Recursively upload entire directories.',
                                action='store_true')
     upload_parser.add_argument('source', help='Local file')
     upload_parser.add_argument('destination', help='Remote file path')

--- a/osfclient/cli.py
+++ b/osfclient/cli.py
@@ -206,7 +206,6 @@ def upload(args):
                  ' password.')
 
     project = osf.project(args.project)
-
     storage, remote_path = split_storage(args.destination)
 
     store = project.storage(storage)
@@ -219,9 +218,10 @@ def upload(args):
             for fname in files:
                 full_path = os.path.join(root, fname)
                 with open(full_path, 'rb') as fp:
+                    # remove storage specifier from path if it exists
+                    _, full_path = split_storage(full_path)
                     name = os.path.join(remote_path, full_path)
-                    #store.create_file(name, fp, update=args.force)
-                    print(store, full_path, name)
+                    store.create_file(name, fp, update=args.force)
 
     else:
         with open(args.source, 'rb') as fp:

--- a/osfclient/cli.py
+++ b/osfclient/cli.py
@@ -210,8 +210,17 @@ def upload(args):
     storage, remote_path = split_storage(args.destination)
 
     store = project.storage(storage)
-    with open(args.source, 'rb') as fp:
-        store.create_file(remote_path, fp, update=args.force)
+    if args.recursive:
+        for root, _, files in os.walk(args.source):
+            for fname in files:
+                full_path = os.path.join(root, fname)
+                with open(full_path, 'rb') as fp:
+                    name = remote_path + full_path
+                    store.create_file(name, fp, update=args.force)
+
+    else:
+        with open(args.source, 'rb') as fp:
+            store.create_file(remote_path, fp, update=args.force)
 
 
 def remove(args):

--- a/osfclient/cli.py
+++ b/osfclient/cli.py
@@ -211,12 +211,17 @@ def upload(args):
 
     store = project.storage(storage)
     if args.recursive:
+        if not os.path.isdir(args.source):
+            raise RuntimeError("Expected source ({}) to be a directory when "
+                               "using recursive mode.".format(args.source))
+
         for root, _, files in os.walk(args.source):
             for fname in files:
                 full_path = os.path.join(root, fname)
                 with open(full_path, 'rb') as fp:
-                    name = remote_path + full_path
-                    store.create_file(name, fp, update=args.force)
+                    name = os.path.join(remote_path, full_path)
+                    #store.create_file(name, fp, update=args.force)
+                    print(store, full_path, name)
 
     else:
         with open(args.source, 'rb') as fp:

--- a/osfclient/tests/mocks.py
+++ b/osfclient/tests/mocks.py
@@ -45,9 +45,10 @@ def MockProject(name):
 
 def MockArgs(username=None, password=None, output=None, project=None,
              source=None, destination=None, local=None, remote=None,
-             target=None, force=False):
+             target=None, force=False, recursive=False):
     args = MagicMock(spec=['username', 'password', 'output', 'project',
-                           'source', 'destination', 'target', 'force'])
+                           'source', 'destination', 'target', 'force',
+                           'recursive'])
     args._username_mock = PropertyMock(return_value=username)
     type(args).username = args._username_mock
     args._password_mock = PropertyMock(return_value=password)
@@ -73,6 +74,9 @@ def MockArgs(username=None, password=None, output=None, project=None,
 
     args._force_mock = PropertyMock(return_value=force)
     type(args).force = args._force_mock
+
+    args._recursive_mock = PropertyMock(return_value=recursive)
+    type(args).recursive = args._recursive_mock
 
     return args
 

--- a/osfclient/tests/test_uploading.py
+++ b/osfclient/tests/test_uploading.py
@@ -83,9 +83,9 @@ def test_recursive_upload(OSF_project):
     # test that we check if source is a directory when using recursive mode
     args = MockArgs(username='joe@example.com',
                     project='1234',
-                    source='foo/',
+                    source='foobar/',
                     recursive=True,
-                    destination='bar/')
+                    destination='BAR/')
 
     def simple_getenv(key):
         if key == 'OSF_PASSWORD':
@@ -94,7 +94,11 @@ def test_recursive_upload(OSF_project):
     fake_open = mock_open()
     fake_storage = OSF_project.return_value.storage.return_value
 
-    dir_contents = [('foo', None, ['bar.txt', 'abc.txt'])]
+    # it is important we use foobar/ and not foobar to match with args.source
+    # to mimick the behaviour of os.walk()
+    dir_contents = [('foobar/', None, ['bar.txt', 'abc.txt']),
+                    ('foobar/baz', None, ['bar.txt', 'abc.txt'])
+                    ]
 
     with patch('osfclient.cli.open', fake_open):
         with patch('os.walk', return_value=iter(dir_contents)):
@@ -102,9 +106,66 @@ def test_recursive_upload(OSF_project):
                 with patch('osfclient.cli.os.path.isdir', return_value=True):
                     upload(args)
 
-    assert call('foo/bar.txt', 'rb') in fake_open.mock_calls
-    assert call('foo/abc.txt', 'rb') in fake_open.mock_calls
+    assert call('foobar/bar.txt', 'rb') in fake_open.mock_calls
+    assert call('foobar/abc.txt', 'rb') in fake_open.mock_calls
+    assert call('foobar/baz/bar.txt', 'rb') in fake_open.mock_calls
+    assert call('foobar/baz/abc.txt', 'rb') in fake_open.mock_calls
+    # two directories with two files each -> four calls plus all the
+    # context manager __enter__ and __exit__ calls
+    assert len(fake_open.mock_calls) == 4 + 4*2
 
-    fake_storage.assert_has_calls(
-        [call.create_file('bar/foo/bar.txt', mock.ANY, update=False),
-         call.create_file('bar/foo/abc.txt', mock.ANY, update=False)])
+    fake_storage.assert_has_calls([
+        call.create_file('BAR/bar.txt', mock.ANY, update=False),
+        call.create_file('BAR/abc.txt', mock.ANY, update=False),
+        call.create_file('BAR/baz/bar.txt', mock.ANY, update=False),
+        call.create_file('BAR/baz/abc.txt', mock.ANY, update=False)
+        ])
+    # two directories with two files each -> four calls
+    assert len(fake_storage.mock_calls) == 4
+
+
+@patch.object(OSF, 'project', return_value=MockProject('1234'))
+def test_recursive_upload_with_subdir(OSF_project):
+    # test that an extra level of subdirectory is created on the remote side
+    # this is because args.source does not end in a /
+    args = MockArgs(username='joe@example.com',
+                    project='1234',
+                    source='foobar',
+                    recursive=True,
+                    destination='BAR/')
+
+    def simple_getenv(key):
+        if key == 'OSF_PASSWORD':
+            return 'secret'
+
+    fake_open = mock_open()
+    fake_storage = OSF_project.return_value.storage.return_value
+
+    # it is important we use foobar and not foobar/ to match with args.source
+    # to mimick the behaviour of os.walk()
+    dir_contents = [('foobar', None, ['bar.txt', 'abc.txt']),
+                    ('foobar/baz', None, ['bar.txt', 'abc.txt'])
+                    ]
+
+    with patch('osfclient.cli.open', fake_open):
+        with patch('os.walk', return_value=iter(dir_contents)):
+            with patch('osfclient.cli.os.getenv', side_effect=simple_getenv):
+                with patch('osfclient.cli.os.path.isdir', return_value=True):
+                    upload(args)
+
+    assert call('foobar/bar.txt', 'rb') in fake_open.mock_calls
+    assert call('foobar/abc.txt', 'rb') in fake_open.mock_calls
+    assert call('foobar/baz/bar.txt', 'rb') in fake_open.mock_calls
+    assert call('foobar/baz/abc.txt', 'rb') in fake_open.mock_calls
+    # two directories with two files each -> four calls plus all the
+    # context manager __enter__ and __exit__ calls
+    assert len(fake_open.mock_calls) == 4 + 4*2
+
+    fake_storage.assert_has_calls([
+        call.create_file('BAR/foobar/bar.txt', mock.ANY, update=False),
+        call.create_file('BAR/foobar/abc.txt', mock.ANY, update=False),
+        call.create_file('BAR/foobar/baz/bar.txt', mock.ANY, update=False),
+        call.create_file('BAR/foobar/baz/abc.txt', mock.ANY, update=False)
+        ])
+    # two directories with two files each -> four calls
+    assert len(fake_storage.mock_calls) == 4


### PR DESCRIPTION
Fixes #18 

This will allow people to upload a whole directory and all files in it. Modelled on how `scp` works. An alternative would be to detect that the `source` is a directory and infer that the user meant to upload everything recursively.