### PR TITLE
add links to GH & intro materials (closes #85 & #82)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,8 @@ As such the OSF hosts large data sets, associated with papers or
 scientific projects, that can be freely downloaded. The *osfclient*
 allows people to store and retrieve large datasets associated to their
 scientific projects and papers on the OSF via the command line
-interface.
+interface. If you are completely new to the OSF you can `read their
+introductory materials <https://cos.io/our-products/open-science-framework/>`__
 
 This is a very new project, it has some rough edges.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,9 +16,11 @@ As such the OSF hosts large data sets, associated with papers or
 scientific projects, that can be freely downloaded. The *osfclient*
 allows people to store and retrieve large datasets associated to their
 scientific projects and papers on the OSF via the command line
-interface.
+interface. If you are completely new to the OSF you can
+read the `OSF introductory materials`.
 
-This is a very new project, it has some rough edges.
+This is a very new project, it has some rough edges. You can find the code for
+the osf-cli in the `GitHub repository`.
 
 
 .. toctree::
@@ -30,3 +32,5 @@ This is a very new project, it has some rough edges.
 
 
 .. _Open Science Framework: https://osf.io
+.. _OSF introductory materials: https://cos.io/our-products/open-science-framework/
+.. _GitHub repository: https://github.com/dib-lab/osf-cli

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,7 +20,7 @@ interface. If you are completely new to the OSF you can
 read the `OSF introductory materials`.
 
 This is a very new project, it has some rough edges. You can find the code for
-the osf-cli in the `GitHub repository`.
+the ``osfclient`` in the `GitHub repository`.
 
 
 .. toctree::


### PR DESCRIPTION
Added the GH link to the readthedocs front page and the intro materials of OSF to the README + readthedocs.