### PR TITLE
include license file in distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,6 @@
 # a pure python module
 [bdist_wheel]
 universal = 1
+
+[metadata]
+license-file = LICENSE


### PR DESCRIPTION
Under your BSD license, redistributions of your code are supposed to include the terms of the license. But your `LICENSE` file currently isn't included by either `sdist` or `bdist_wheel`. The `MANIFEST.in` file makes sure that `sdist` includes it, and the `setup.cfg` change handles it for wheels.