### PR TITLE
change ls to list in getting started docs

### DIFF
--- a/docs/cli-usage.rst
+++ b/docs/cli-usage.rst
@@ -16,14 +16,14 @@ Below some examples on how to use the command-line program:
     $ osf <command> -h
 
     # list all files for a public project
-    $ osf -p <projectid> ls
+    $ osf -p <projectid> list
 
     # setup a local folder for an existing project
     $ osf init
 
     # list all files for a private project
     # set $OSF_PASSWORD to provide the password
-    $ osf -p <projectid> -u yourOSFacount@example.com ls
+    $ osf -p <projectid> -u yourOSFacount@example.com list
 
     # fetch all files from a project and store them in `output_directory`
     $ osf -p <projectid> clone [output_directory]
@@ -58,7 +58,7 @@ current directory. To set the username and project ID create
     project = 9zpcy
 
 
-after which you can simply run `osf ls` to list the contents of the project.
+after which you can simply run `osf list` to list the contents of the project.
 
 
 .. _OSF: https://osf.io

--- a/docs/cli-usage.rst
+++ b/docs/cli-usage.rst
@@ -40,6 +40,8 @@ Below some examples on how to use the command-line program:
     # remove a single file from an OSF project
     $ osf -p <projectid> remove remote/file.txt
 
+If you're using python 3+, you can also use the aliases `ls` in place of `list`, and `rm` in place of `remove`.
+
 
 If the project is private you will need to provide authentication
 details. You can provide your OSF account name as command-line argument


### PR DESCRIPTION
Setting up, noticed that `ls` was at some point changed to `list` -- as per the super helpful command line feedback!

![screen shot 2017-10-13 at 9 25 17 am](https://user-images.githubusercontent.com/801594/31548341-7d1d9228-aff8-11e7-87d7-a5f60a9ed1f7.png)
